### PR TITLE
feat(): Create setup for ThreeJS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,16 @@
       "name": "sopra-fs22-client-template",
       "version": "0.1.0",
       "dependencies": {
+        "@react-three/drei": "^9.0.1",
+        "@react-three/fiber": "^8.0.4",
         "axios": "^0.24.0",
         "node-gyp": "^8.4.1",
         "node-sass": "^7.0.1",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0",
         "react-router-dom": "^5.3.0",
-        "react-scripts": "^5.0.0"
+        "react-scripts": "^5.0.0",
+        "three": "^0.139.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1761,9 +1764,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.5.tgz",
-      "integrity": "sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==",
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.8.tgz",
+      "integrity": "sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -1832,6 +1835,35 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
+    },
+    "node_modules/@chevrotain/cst-dts-gen": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-10.1.2.tgz",
+      "integrity": "sha512-E/XrL0QlzExycPzwhOEZGVOheJ/Clr5uNv3oCds88MiNqEmg3UU1iauZk7DhjsUo3jgEW4lf0I5HRl7/HC5ZkQ==",
+      "dependencies": {
+        "@chevrotain/gast": "^10.1.2",
+        "@chevrotain/types": "^10.1.2",
+        "lodash": "4.17.21"
+      }
+    },
+    "node_modules/@chevrotain/gast": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-10.1.2.tgz",
+      "integrity": "sha512-er+TcxUOMuGOPoiOq8CJsRm92zGE4YPIYtyxJfxoVwVgtj4AMrPNCmrHvYaK/bsbt2DaDuFdcbbAfM9bcBXW6Q==",
+      "dependencies": {
+        "@chevrotain/types": "^10.1.2",
+        "lodash": "4.17.21"
+      }
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-10.1.2.tgz",
+      "integrity": "sha512-4qF9SmmWKv8AIG/3d+71VFuqLumNCQTP5GoL0CW6x7Ay2OdXm6FUgWFLTMneGUjYUk2C+MSCf7etQfdq3LEr1A=="
+    },
+    "node_modules/@chevrotain/utils": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.1.2.tgz",
+      "integrity": "sha512-bbZIpW6fdyf7FMaeDmw3cBbkTqsecxEkwlVKgVfqqXWBPLH6azxhPA2V9F7OhoZSVrsnMYw7QuyK6qutXPjEew=="
     },
     "node_modules/@csstools/normalize.css": {
       "version": "12.0.0",
@@ -2710,6 +2742,150 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@react-spring/rafz": {
+      "version": "9.4.4",
+      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-9.4.4.tgz",
+      "integrity": "sha512-5ki/sQ06Mdf8AuFstSt5zbNNicRT4LZogiJttDAww1ozhuvemafNWEHxhzcULgCPCDu2s7HsroaISV7+GQWrhw=="
+    },
+    "node_modules/@react-spring/three": {
+      "version": "9.4.4",
+      "resolved": "https://registry.npmjs.org/@react-spring/three/-/three-9.4.4.tgz",
+      "integrity": "sha512-z77ohxg8zG0CcZJojzfoJTTrjSbIyefNz2RlId68/4IypnOs1p8kB2Q1p+wX4KyWORpLg8ivsPcjtwBjGwfDtg==",
+      "dependencies": {
+        "@react-spring/animated": "~9.4.4",
+        "@react-spring/core": "~9.4.4",
+        "@react-spring/shared": "~9.4.4",
+        "@react-spring/types": "~9.4.4"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": ">=6.0",
+        "react": ">=16.11",
+        "three": ">=0.126"
+      }
+    },
+    "node_modules/@react-spring/three/node_modules/@react-spring/animated": {
+      "version": "9.4.4",
+      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.4.4.tgz",
+      "integrity": "sha512-e9xnuBaUTD+NolKikUmrGWjX8AVCPyj1GcEgjgq9E+0sXKv46UY7cm2EmB6mUDTxWIDVKebARY++xT4nGDraBQ==",
+      "dependencies": {
+        "@react-spring/shared": "~9.4.4",
+        "@react-spring/types": "~9.4.4"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0  || ^17.0.0"
+      }
+    },
+    "node_modules/@react-spring/three/node_modules/@react-spring/core": {
+      "version": "9.4.4",
+      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.4.4.tgz",
+      "integrity": "sha512-llgb0ljFyjMB0JhWsaFHOi9XFT8n1jBMVs1IFY2ipIBerWIRWrgUmIpakLPHTa4c4jwqTaDSwX90s2a0iN7dxQ==",
+      "dependencies": {
+        "@react-spring/animated": "~9.4.4",
+        "@react-spring/rafz": "~9.4.4",
+        "@react-spring/shared": "~9.4.4",
+        "@react-spring/types": "~9.4.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-spring/donate"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0  || ^17.0.0"
+      }
+    },
+    "node_modules/@react-spring/three/node_modules/@react-spring/shared": {
+      "version": "9.4.4",
+      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.4.4.tgz",
+      "integrity": "sha512-ySVgScDZlhm/+Iy2smY9i/DDrShArY0j6zjTS/Re1lasKnhq8qigoGiAxe8xMPJNlCaj3uczCqHy3TY9bKRtfQ==",
+      "dependencies": {
+        "@react-spring/rafz": "~9.4.4",
+        "@react-spring/types": "~9.4.4"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0  || ^17.0.0"
+      }
+    },
+    "node_modules/@react-spring/types": {
+      "version": "9.4.4",
+      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.4.4.tgz",
+      "integrity": "sha512-KpxKt/D//q/t/6FBcde/RE36LKp8PpWu7kFEMLwpzMGl9RpcexunmYOQJWwmJWtkQjgE1YRr7DzBMryz6La1cQ=="
+    },
+    "node_modules/@react-three/drei": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-9.0.1.tgz",
+      "integrity": "sha512-sVZP7BGiPoydihj3H2jukV3LKRHfmRjifFbQf7fxcRADy5IuCtqP+doFtIQNzaGGQT9uPS6dCSxK3t9AQ+OVtQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.11.2",
+        "@react-spring/three": "^9.3.1",
+        "@use-gesture/react": "^10.2.0",
+        "detect-gpu": "^4.0.14",
+        "glsl-noise": "^0.0.0",
+        "lodash.omit": "^4.5.0",
+        "lodash.pick": "^4.4.0",
+        "meshline": "^2.0.4",
+        "react-composer": "^5.0.2",
+        "react-merge-refs": "^1.1.0",
+        "stats.js": "^0.17.0",
+        "suspend-react": "^0.0.8",
+        "three-mesh-bvh": "^0.5.7",
+        "three-stdlib": "^2.8.12",
+        "troika-three-text": "^0.46.3",
+        "utility-types": "^3.10.0",
+        "zustand": "^3.5.13"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": ">=8.0",
+        "react": ">=18.0",
+        "react-dom": ">=18.0",
+        "three": ">=0.137"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-8.0.4.tgz",
+      "integrity": "sha512-TMk1/SYYXcCaVOTRE2855LiL6X0k5Fwq9ylISHY6hwJk6IG7D8QA077M2Fsm+xrcMERk8LTL0E8NGNT81+u+4Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/react-reconciler": "^0.26.4",
+        "react-merge-refs": "^1.1.0",
+        "react-reconciler": "^0.27.0",
+        "react-use-measure": "^2.1.1",
+        "scheduler": "^0.21.0",
+        "suspend-react": "^0.0.8",
+        "zustand": "^3.7.1"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-gl": ">=11.0",
+        "react": ">=18.0",
+        "react-dom": ">=18.0",
+        "react-native": ">=0.64",
+        "three": ">=0.133"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.0.tgz",
@@ -3213,10 +3389,33 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.2.tgz",
       "integrity": "sha512-ekoj4qOQYp7CvjX8ZDBgN86w3MqQhLE1hczEJbEIjgFEumDy+na/4AJAbLXfgEWFNB2pKadM5rPFtuSGMWK7xA=="
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.4",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
+    },
     "node_modules/@types/q": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
+    },
+    "node_modules/@types/react": {
+      "version": "17.0.43",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.43.tgz",
+      "integrity": "sha512-8Q+LNpdxf057brvPu1lMtC5Vn7J119xrP1aq4qiaefNioQUYANF/CYeK4NsKorSZyUGJ66g0IM+4bbjwx45o2A==",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.26.4",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.26.4.tgz",
+      "integrity": "sha512-bdx4aIBkQRDAnzc23JBFeZmVpmfLJHfHikmQukEt9qs4bQtq9f+PDbNwhR9u74FkIUyIDz1I1qJ8OF6RwadKpw==",
+      "dependencies": {
+        "@types/react": "*"
+      }
     },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
@@ -3230,6 +3429,11 @@
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
+    },
+    "node_modules/@types/scheduler": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -3432,6 +3636,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@use-gesture/core": {
+      "version": "10.2.10",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.2.10.tgz",
+      "integrity": "sha512-7WFIDfeTB+7RBui8YOrB2xbgmvMsvaCDjyzrdvECKkgOpIynNSdhlLXjiFuqQMtnK71IL/9WNZNU0P8xuaLuUQ=="
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.2.10",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.2.10.tgz",
+      "integrity": "sha512-znChnKVAMMGXD9J7fCKN686BJNBlUJaRtCu92IQXVWdcxg4MqS0SgsBslGnTWXTlsHVkg5zcGjKYf7qYkOf0Rg==",
+      "dependencies": {
+        "@use-gesture/core": "10.2.10"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
+      }
+    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
@@ -3562,6 +3782,11 @@
         "@webassemblyjs/ast": "1.11.1",
         "@xtuc/long": "4.2.2"
       }
+    },
+    "node_modules/@webgpu/glslang": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/@webgpu/glslang/-/glslang-0.0.15.tgz",
+      "integrity": "sha512-niT+Prh3Aff8Uf1MVBVUsaNjFj9rJAKDXuoHIKiQbB+6IUP/3J3JIhBNyZ7lDhytvXxw6ppgnwKZdDJ08UMj4Q=="
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
@@ -4438,6 +4663,14 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.2.tgz",
+      "integrity": "sha512-rzSy/k7WdX5zOyeHHCOixGXbCHkyogkxPKL2r8QtzHmVQDiWCXUWa18bLdMWT9CYMLOYTjWpTHawuev2ouYJVw==",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -4790,6 +5023,19 @@
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.1.2.tgz",
       "integrity": "sha512-tzWzvgePgLORb9/3a0YenggReLKAIb2owL03H2Xdoe5pKcUyWRSEQ8xfCar8t2SIAuEDwtmx2da1YB52YuHQMQ=="
+    },
+    "node_modules/chevrotain": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-10.1.2.tgz",
+      "integrity": "sha512-hvRiQuhhTZxkPMGD/dke+s1EGo8AkKDBU05CcufBO278qgAQSwIC4QyLdHz0CFHVtqVYWjlAS5D1KwvBbaHT+w==",
+      "dependencies": {
+        "@chevrotain/cst-dts-gen": "^10.1.2",
+        "@chevrotain/gast": "^10.1.2",
+        "@chevrotain/types": "^10.1.2",
+        "@chevrotain/utils": "^10.1.2",
+        "lodash": "4.17.21",
+        "regexp-to-ast": "0.5.0"
+      }
     },
     "node_modules/chokidar": {
       "version": "3.5.2",
@@ -5536,6 +5782,11 @@
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
     },
+    "node_modules/csstype": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
+      "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw=="
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.7.tgz",
@@ -5564,6 +5815,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="
     },
     "node_modules/debug": {
       "version": "4.3.3",
@@ -5729,6 +5985,14 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "node_modules/detect-gpu": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-4.0.15.tgz",
+      "integrity": "sha512-Tjyu2oH3Dyhb74+TK/4z4LxyO+nPDT2Y+Dznqt1+7zNNCUz/3y1WjIXDpSxXjTfVdADXne18XCpKRb38YHOwGw==",
+      "dependencies": {
+        "webgl-constants": "^1.1.1"
+      }
     },
     "node_modules/detect-newline": {
       "version": "3.1.0",
@@ -5957,6 +6221,11 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA=="
+    },
+    "node_modules/draco3d": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.2.tgz",
+      "integrity": "sha512-AeRQ25Fb29c14vpjnh167UGW0nGY0ZpEM3ld+zEXoEySlmEXcXfsCHZeTgo5qXH925V1JsdjrzasdaQ22/vXog=="
     },
     "node_modules/duplexer": {
       "version": "0.1.2",
@@ -7110,6 +7379,11 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
+      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg=="
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -7802,6 +8076,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/glsl-noise": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
+      "integrity": "sha1-NndF86MzgsDu7Ey1S36Zz8HXZws="
     },
     "node_modules/graceful-fs": {
       "version": "4.2.6",
@@ -10855,6 +11134,11 @@
         "node": ">= 8"
       }
     },
+    "node_modules/ktx-parse": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/ktx-parse/-/ktx-parse-0.2.2.tgz",
+      "integrity": "sha512-cFBc1jnGG2WlUf52NbDUXK2obJ+Mo9WUkBRvr6tP6CKxRMvZwDDFNV3JAS4cewETp5KyexByfWm9sm+O8AffiQ=="
+    },
     "node_modules/language-subtag-registry": {
       "version": "0.3.21",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.21.tgz",
@@ -10955,6 +11239,16 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "node_modules/lodash.omit": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
+    },
+    "node_modules/lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
     },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
@@ -11138,6 +11432,14 @@
         "node": ">= 8"
       }
     },
+    "node_modules/meshline": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/meshline/-/meshline-2.0.4.tgz",
+      "integrity": "sha512-Jh6DJl/zLqA4xsKvGv5950jr2ukyXQE1wgxs8u94cImHrvL6soVIggqjP+2hVHZXGYaKnWszhtjuCbKNeQyYiw==",
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -11202,19 +11504,6 @@
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/mini-create-react-context": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
-      "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.1",
-        "tiny-warning": "^1.0.3"
-      },
-      "peerDependencies": {
-        "prop-types": "^15.0.0",
-        "react": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/mini-css-extract-plugin": {
@@ -11411,6 +11700,11 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/mmd-parser": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mmd-parser/-/mmd-parser-1.0.4.tgz",
+      "integrity": "sha512-Qi0VCU46t2IwfGv5KF0+D/t9cizcDug7qnNoy9Ggk7aucp0tssV8IwTMkBlDbm+VqAf3cdQHTCARKSsuS2MYFg=="
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -11939,6 +12233,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/opentype.js": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/opentype.js/-/opentype.js-1.3.4.tgz",
+      "integrity": "sha512-d2JE9RP/6uagpQAVtJoF0pJJA/fgai89Cc50Yp0EJHk+eLp6QQ7gBoblsnubRULNY132I0J1QKMJ+JTbMqz4sw==",
+      "dependencies": {
+        "string.prototype.codepointat": "^0.2.1",
+        "tiny-inflate": "^1.0.3"
+      },
+      "bin": {
+        "ot": "bin/ot"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/optionator": {
@@ -13464,6 +13773,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "node_modules/potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ=="
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -13731,12 +14045,11 @@
       }
     },
     "node_modules/react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.0.0.tgz",
+      "integrity": "sha512-x+VL6wbT4JRVPm7EGxXhZ8w8LTROaxPXOqhlGyVSrv0sB1jkyFGgXxJ8LVoPRLvPR6/CIZGFmfzqUa2NYeMr2A==",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -13756,6 +14069,17 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/react-composer": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/react-composer/-/react-composer-5.0.2.tgz",
+      "integrity": "sha512-6E2UNjUF0e7KRY+/faU2Hv7D9zagXnYdTfSSCGdYfuds6mRnVpN19vrbHXShaQzJNVXL4VOUb8qq6DvClDIG1g==",
+      "dependencies": {
+        "prop-types": "^15.6.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/react-dev-utils": {
@@ -13876,16 +14200,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.0.0.tgz",
+      "integrity": "sha512-XqX7uzmFo0pUceWFCt7Gff6IyIMzFUn7QMZrbrQfGxtaxXZIcGQzoNpRLE3fQLnS4XzLLPMZX2T9TRcSrasicw==",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
+        "scheduler": "^0.21.0"
       },
       "peerDependencies": {
-        "react": "17.0.2"
+        "react": "^18.0.0"
       }
     },
     "node_modules/react-error-overlay": {
@@ -13897,6 +14220,30 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "node_modules/react-merge-refs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-1.1.0.tgz",
+      "integrity": "sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/gregberge"
+      }
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.27.0.tgz",
+      "integrity": "sha512-HmMDKciQjYmBRGuuhIaKA1ba/7a+UsM5FzOZsMO2JYHt9Jh8reCb7j1eDC95NOyUlKM9KRyvdx0flBuDvYSBoA==",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.21.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.11.0",
@@ -13947,6 +14294,19 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+    },
+    "node_modules/react-router/node_modules/mini-create-react-context": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
+      "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.1",
+        "tiny-warning": "^1.0.3"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.0.0",
+        "react": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
     },
     "node_modules/react-router/node_modules/path-to-regexp": {
       "version": "1.8.0",
@@ -14031,6 +14391,18 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-use-measure": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.1.tgz",
+      "integrity": "sha512-nocZhN26cproIiIduswYpV5y5lQpSQS1y/4KuvUCjSKmw7ZWIS/+g3aFnX3WdBkyuGUtTLif3UTqnLLhbDoQig==",
+      "dependencies": {
+        "debounce": "^1.2.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
       }
     },
     "node_modules/read-pkg": {
@@ -14217,6 +14589,11 @@
       "version": "2.2.11",
       "resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.2.11.tgz",
       "integrity": "sha512-jbD/FT0+9MBU2XAZluI7w2OBs1RBi6p9M83nkoZayQXXU9e8Robt69FcZc7wU4eJD/YFTjn1JdCk3rbMJajz8Q=="
+    },
+    "node_modules/regexp-to-ast": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
+      "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.3.1",
@@ -14787,12 +15164,11 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+      "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/schema-utils": {
@@ -15284,6 +15660,11 @@
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
       "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA=="
     },
+    "node_modules/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha1-scPcRtlEmLV4t/05hbgaznExzH0="
+    },
     "node_modules/statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
@@ -15378,6 +15759,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/string.prototype.codepointat": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
+      "integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg=="
     },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.6",
@@ -15561,6 +15947,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/suspend-react": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.0.8.tgz",
+      "integrity": "sha512-ZC3r8Hu1y0dIThzsGw0RLZplnX9yXwfItcvaIzJc2VQVi8TGyGDlu92syMB5ulybfvGLHAI5Ghzlk23UBPF8xg==",
+      "peerDependencies": {
+        "react": ">=17.0"
       }
     },
     "node_modules/svg-parser": {
@@ -15896,6 +16290,39 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
+    "node_modules/three": {
+      "version": "0.139.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.139.1.tgz",
+      "integrity": "sha512-7mV5mk7k9CyNnRBXBo8VDWw0haONMh+czKfGFCaYhKq79br2z+4TxZe4JurM6/IGsLU3VaP8CydfDsifvZvg8w=="
+    },
+    "node_modules/three-mesh-bvh": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.5.8.tgz",
+      "integrity": "sha512-aw1hGGKP91WC98vDh+M7yGczwnmmtbcCwDjsh7hls076S91GuSfWbCoym3GK64uR0BhySlV5mEitCKQu3o7srg==",
+      "peerDependencies": {
+        "three": ">= 0.123.0"
+      }
+    },
+    "node_modules/three-stdlib": {
+      "version": "2.8.12",
+      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.8.12.tgz",
+      "integrity": "sha512-Y0pl6mQKWM5rkdOYrx4PDFwMYEEx34z4bPwKALOqEtpjaZkWhiPpu7FKtipLiVdTd+Sw8Opty4q0QmJLZ2+Y4A==",
+      "dependencies": {
+        "@babel/runtime": "^7.16.7",
+        "@webgpu/glslang": "^0.0.15",
+        "chevrotain": "^10.1.2",
+        "draco3d": "^1.4.1",
+        "fflate": "^0.6.9",
+        "ktx-parse": "^0.2.1",
+        "mmd-parser": "^1.0.4",
+        "opentype.js": "^1.3.3",
+        "potpack": "^1.0.1",
+        "zstddec": "^0.0.2"
+      },
+      "peerDependencies": {
+        "three": ">=0.122.0"
+      }
+    },
     "node_modules/throat": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
@@ -15910,6 +16337,11 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="
     },
     "node_modules/tiny-invariant": {
       "version": "1.2.0",
@@ -16003,6 +16435,33 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/troika-three-text": {
+      "version": "0.46.4",
+      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.46.4.tgz",
+      "integrity": "sha512-Qsv0HhUKTZgSmAJs5wvO7YlBoJSP9TGPLmrg+K9pbQq4lseQdcevbno/WI38bwJBZ/qS56hvfqEzY0zUEFzDIw==",
+      "dependencies": {
+        "bidi-js": "^1.0.2",
+        "troika-three-utils": "^0.46.0",
+        "troika-worker-utils": "^0.46.0",
+        "webgl-sdf-generator": "1.1.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.103.0"
+      }
+    },
+    "node_modules/troika-three-utils": {
+      "version": "0.46.0",
+      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.46.0.tgz",
+      "integrity": "sha512-llHyrXAcwzr0bpg80GxsIp73N7FuImm4WCrKDJkAqcAsWmE5pfP9+Qzw+oMWK1P/AdHQ79eOrOl9NjyW4aOw0w==",
+      "peerDependencies": {
+        "three": ">=0.103.0"
+      }
+    },
+    "node_modules/troika-worker-utils": {
+      "version": "0.46.0",
+      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.46.0.tgz",
+      "integrity": "sha512-bzOx5f2ZBxkFhXtIvDJlLn2AI3bzCkGVbCndl/2dL5QZrwHEKl45OEIilCxYQQWJG1rEbOD9O80tMjoYjw19OA=="
     },
     "node_modules/true-case-path": {
       "version": "1.0.3",
@@ -16303,6 +16762,14 @@
       "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
       "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw="
     },
+    "node_modules/utility-types": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.10.0.tgz",
+      "integrity": "sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -16426,6 +16893,16 @@
       "dependencies": {
         "minimalistic-assert": "^1.0.0"
       }
+    },
+    "node_modules/webgl-constants": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
+    },
+    "node_modules/webgl-sdf-generator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
+      "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA=="
     },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",
@@ -17314,6 +17791,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zstddec": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.0.2.tgz",
+      "integrity": "sha512-DCo0oxvcvOTGP/f5FA6tz2Z6wF+FIcEApSTu0zV5sQgn9hoT5lZ9YRAKUraxt9oP7l4e8TnNdi8IZTCX6WCkwA=="
+    },
+    "node_modules/zustand": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.7.1.tgz",
+      "integrity": "sha512-wHBCZlKj+bg03/hP+Tzv24YhnqqP8MCeN9ECPDXoF01062SIbnfl3j9O0znkDw1lNTY0a8WN3F///a0UhhaEqg==",
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     }
   },
@@ -18484,9 +18982,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.5.tgz",
-      "integrity": "sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==",
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.8.tgz",
+      "integrity": "sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -18540,6 +19038,35 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
+    },
+    "@chevrotain/cst-dts-gen": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-10.1.2.tgz",
+      "integrity": "sha512-E/XrL0QlzExycPzwhOEZGVOheJ/Clr5uNv3oCds88MiNqEmg3UU1iauZk7DhjsUo3jgEW4lf0I5HRl7/HC5ZkQ==",
+      "requires": {
+        "@chevrotain/gast": "^10.1.2",
+        "@chevrotain/types": "^10.1.2",
+        "lodash": "4.17.21"
+      }
+    },
+    "@chevrotain/gast": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-10.1.2.tgz",
+      "integrity": "sha512-er+TcxUOMuGOPoiOq8CJsRm92zGE4YPIYtyxJfxoVwVgtj4AMrPNCmrHvYaK/bsbt2DaDuFdcbbAfM9bcBXW6Q==",
+      "requires": {
+        "@chevrotain/types": "^10.1.2",
+        "lodash": "4.17.21"
+      }
+    },
+    "@chevrotain/types": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-10.1.2.tgz",
+      "integrity": "sha512-4qF9SmmWKv8AIG/3d+71VFuqLumNCQTP5GoL0CW6x7Ay2OdXm6FUgWFLTMneGUjYUk2C+MSCf7etQfdq3LEr1A=="
+    },
+    "@chevrotain/utils": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.1.2.tgz",
+      "integrity": "sha512-bbZIpW6fdyf7FMaeDmw3cBbkTqsecxEkwlVKgVfqqXWBPLH6azxhPA2V9F7OhoZSVrsnMYw7QuyK6qutXPjEew=="
     },
     "@csstools/normalize.css": {
       "version": "12.0.0",
@@ -19173,6 +19700,97 @@
         }
       }
     },
+    "@react-spring/rafz": {
+      "version": "9.4.4",
+      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-9.4.4.tgz",
+      "integrity": "sha512-5ki/sQ06Mdf8AuFstSt5zbNNicRT4LZogiJttDAww1ozhuvemafNWEHxhzcULgCPCDu2s7HsroaISV7+GQWrhw=="
+    },
+    "@react-spring/three": {
+      "version": "9.4.4",
+      "resolved": "https://registry.npmjs.org/@react-spring/three/-/three-9.4.4.tgz",
+      "integrity": "sha512-z77ohxg8zG0CcZJojzfoJTTrjSbIyefNz2RlId68/4IypnOs1p8kB2Q1p+wX4KyWORpLg8ivsPcjtwBjGwfDtg==",
+      "requires": {
+        "@react-spring/animated": "~9.4.4",
+        "@react-spring/core": "~9.4.4",
+        "@react-spring/shared": "~9.4.4",
+        "@react-spring/types": "~9.4.4"
+      },
+      "dependencies": {
+        "@react-spring/animated": {
+          "version": "9.4.4",
+          "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.4.4.tgz",
+          "integrity": "sha512-e9xnuBaUTD+NolKikUmrGWjX8AVCPyj1GcEgjgq9E+0sXKv46UY7cm2EmB6mUDTxWIDVKebARY++xT4nGDraBQ==",
+          "requires": {
+            "@react-spring/shared": "~9.4.4",
+            "@react-spring/types": "~9.4.4"
+          }
+        },
+        "@react-spring/core": {
+          "version": "9.4.4",
+          "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.4.4.tgz",
+          "integrity": "sha512-llgb0ljFyjMB0JhWsaFHOi9XFT8n1jBMVs1IFY2ipIBerWIRWrgUmIpakLPHTa4c4jwqTaDSwX90s2a0iN7dxQ==",
+          "requires": {
+            "@react-spring/animated": "~9.4.4",
+            "@react-spring/rafz": "~9.4.4",
+            "@react-spring/shared": "~9.4.4",
+            "@react-spring/types": "~9.4.4"
+          }
+        },
+        "@react-spring/shared": {
+          "version": "9.4.4",
+          "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.4.4.tgz",
+          "integrity": "sha512-ySVgScDZlhm/+Iy2smY9i/DDrShArY0j6zjTS/Re1lasKnhq8qigoGiAxe8xMPJNlCaj3uczCqHy3TY9bKRtfQ==",
+          "requires": {
+            "@react-spring/rafz": "~9.4.4",
+            "@react-spring/types": "~9.4.4"
+          }
+        }
+      }
+    },
+    "@react-spring/types": {
+      "version": "9.4.4",
+      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.4.4.tgz",
+      "integrity": "sha512-KpxKt/D//q/t/6FBcde/RE36LKp8PpWu7kFEMLwpzMGl9RpcexunmYOQJWwmJWtkQjgE1YRr7DzBMryz6La1cQ=="
+    },
+    "@react-three/drei": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-9.0.1.tgz",
+      "integrity": "sha512-sVZP7BGiPoydihj3H2jukV3LKRHfmRjifFbQf7fxcRADy5IuCtqP+doFtIQNzaGGQT9uPS6dCSxK3t9AQ+OVtQ==",
+      "requires": {
+        "@babel/runtime": "^7.11.2",
+        "@react-spring/three": "^9.3.1",
+        "@use-gesture/react": "^10.2.0",
+        "detect-gpu": "^4.0.14",
+        "glsl-noise": "^0.0.0",
+        "lodash.omit": "^4.5.0",
+        "lodash.pick": "^4.4.0",
+        "meshline": "^2.0.4",
+        "react-composer": "^5.0.2",
+        "react-merge-refs": "^1.1.0",
+        "stats.js": "^0.17.0",
+        "suspend-react": "^0.0.8",
+        "three-mesh-bvh": "^0.5.7",
+        "three-stdlib": "^2.8.12",
+        "troika-three-text": "^0.46.3",
+        "utility-types": "^3.10.0",
+        "zustand": "^3.5.13"
+      }
+    },
+    "@react-three/fiber": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-8.0.4.tgz",
+      "integrity": "sha512-TMk1/SYYXcCaVOTRE2855LiL6X0k5Fwq9ylISHY6hwJk6IG7D8QA077M2Fsm+xrcMERk8LTL0E8NGNT81+u+4Q==",
+      "requires": {
+        "@babel/runtime": "^7.17.8",
+        "@types/react-reconciler": "^0.26.4",
+        "react-merge-refs": "^1.1.0",
+        "react-reconciler": "^0.27.0",
+        "react-use-measure": "^2.1.1",
+        "scheduler": "^0.21.0",
+        "suspend-react": "^0.0.8",
+        "zustand": "^3.7.1"
+      }
+    },
     "@rollup/plugin-babel": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.0.tgz",
@@ -19538,10 +20156,33 @@
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.2.tgz",
       "integrity": "sha512-ekoj4qOQYp7CvjX8ZDBgN86w3MqQhLE1hczEJbEIjgFEumDy+na/4AJAbLXfgEWFNB2pKadM5rPFtuSGMWK7xA=="
     },
+    "@types/prop-types": {
+      "version": "15.7.4",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
+    },
     "@types/q": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
+    },
+    "@types/react": {
+      "version": "17.0.43",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.43.tgz",
+      "integrity": "sha512-8Q+LNpdxf057brvPu1lMtC5Vn7J119xrP1aq4qiaefNioQUYANF/CYeK4NsKorSZyUGJ66g0IM+4bbjwx45o2A==",
+      "requires": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-reconciler": {
+      "version": "0.26.4",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.26.4.tgz",
+      "integrity": "sha512-bdx4aIBkQRDAnzc23JBFeZmVpmfLJHfHikmQukEt9qs4bQtq9f+PDbNwhR9u74FkIUyIDz1I1qJ8OF6RwadKpw==",
+      "requires": {
+        "@types/react": "*"
+      }
     },
     "@types/resolve": {
       "version": "1.17.1",
@@ -19555,6 +20196,11 @@
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
+    },
+    "@types/scheduler": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "@types/stack-utils": {
       "version": "2.0.1",
@@ -19676,6 +20322,19 @@
       "requires": {
         "@typescript-eslint/types": "5.7.0",
         "eslint-visitor-keys": "^3.0.0"
+      }
+    },
+    "@use-gesture/core": {
+      "version": "10.2.10",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.2.10.tgz",
+      "integrity": "sha512-7WFIDfeTB+7RBui8YOrB2xbgmvMsvaCDjyzrdvECKkgOpIynNSdhlLXjiFuqQMtnK71IL/9WNZNU0P8xuaLuUQ=="
+    },
+    "@use-gesture/react": {
+      "version": "10.2.10",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.2.10.tgz",
+      "integrity": "sha512-znChnKVAMMGXD9J7fCKN686BJNBlUJaRtCu92IQXVWdcxg4MqS0SgsBslGnTWXTlsHVkg5zcGjKYf7qYkOf0Rg==",
+      "requires": {
+        "@use-gesture/core": "10.2.10"
       }
     },
     "@webassemblyjs/ast": {
@@ -19808,6 +20467,11 @@
         "@webassemblyjs/ast": "1.11.1",
         "@xtuc/long": "4.2.2"
       }
+    },
+    "@webgpu/glslang": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/@webgpu/glslang/-/glslang-0.0.15.tgz",
+      "integrity": "sha512-niT+Prh3Aff8Uf1MVBVUsaNjFj9rJAKDXuoHIKiQbB+6IUP/3J3JIhBNyZ7lDhytvXxw6ppgnwKZdDJ08UMj4Q=="
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -20466,6 +21130,14 @@
         "tryer": "^1.0.1"
       }
     },
+    "bidi-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.2.tgz",
+      "integrity": "sha512-rzSy/k7WdX5zOyeHHCOixGXbCHkyogkxPKL2r8QtzHmVQDiWCXUWa18bLdMWT9CYMLOYTjWpTHawuev2ouYJVw==",
+      "requires": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -20738,6 +21410,19 @@
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.1.2.tgz",
       "integrity": "sha512-tzWzvgePgLORb9/3a0YenggReLKAIb2owL03H2Xdoe5pKcUyWRSEQ8xfCar8t2SIAuEDwtmx2da1YB52YuHQMQ=="
+    },
+    "chevrotain": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-10.1.2.tgz",
+      "integrity": "sha512-hvRiQuhhTZxkPMGD/dke+s1EGo8AkKDBU05CcufBO278qgAQSwIC4QyLdHz0CFHVtqVYWjlAS5D1KwvBbaHT+w==",
+      "requires": {
+        "@chevrotain/cst-dts-gen": "^10.1.2",
+        "@chevrotain/gast": "^10.1.2",
+        "@chevrotain/types": "^10.1.2",
+        "@chevrotain/utils": "^10.1.2",
+        "lodash": "4.17.21",
+        "regexp-to-ast": "0.5.0"
+      }
     },
     "chokidar": {
       "version": "3.5.2",
@@ -21284,6 +21969,11 @@
         }
       }
     },
+    "csstype": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
+      "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw=="
+    },
     "damerau-levenshtein": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.7.tgz",
@@ -21306,6 +21996,11 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
+    },
+    "debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="
     },
     "debug": {
       "version": "4.3.3",
@@ -21429,6 +22124,14 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "detect-gpu": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-4.0.15.tgz",
+      "integrity": "sha512-Tjyu2oH3Dyhb74+TK/4z4LxyO+nPDT2Y+Dznqt1+7zNNCUz/3y1WjIXDpSxXjTfVdADXne18XCpKRb38YHOwGw==",
+      "requires": {
+        "webgl-constants": "^1.1.1"
+      }
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -21613,6 +22316,11 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA=="
+    },
+    "draco3d": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.2.tgz",
+      "integrity": "sha512-AeRQ25Fb29c14vpjnh167UGW0nGY0ZpEM3ld+zEXoEySlmEXcXfsCHZeTgo5qXH925V1JsdjrzasdaQ22/vXog=="
     },
     "duplexer": {
       "version": "0.1.2",
@@ -22480,6 +23188,11 @@
         "bser": "2.1.1"
       }
     },
+    "fflate": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
+      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg=="
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -22966,6 +23679,11 @@
         "lodash": "~4.17.10",
         "minimatch": "~3.0.2"
       }
+    },
+    "glsl-noise": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
+      "integrity": "sha1-NndF86MzgsDu7Ey1S36Zz8HXZws="
     },
     "graceful-fs": {
       "version": "4.2.6",
@@ -25187,6 +25905,11 @@
       "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.5.tgz",
       "integrity": "sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ=="
     },
+    "ktx-parse": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/ktx-parse/-/ktx-parse-0.2.2.tgz",
+      "integrity": "sha512-cFBc1jnGG2WlUf52NbDUXK2obJ+Mo9WUkBRvr6tP6CKxRMvZwDDFNV3JAS4cewETp5KyexByfWm9sm+O8AffiQ=="
+    },
     "language-subtag-registry": {
       "version": "0.3.21",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.21.tgz",
@@ -25266,6 +25989,16 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "lodash.omit": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
+    },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -25412,6 +26145,12 @@
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
     },
+    "meshline": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/meshline/-/meshline-2.0.4.tgz",
+      "integrity": "sha512-Jh6DJl/zLqA4xsKvGv5950jr2ukyXQE1wgxs8u94cImHrvL6soVIggqjP+2hVHZXGYaKnWszhtjuCbKNeQyYiw==",
+      "requires": {}
+    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -25453,15 +26192,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
-    },
-    "mini-create-react-context": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
-      "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
-      "requires": {
-        "@babel/runtime": "^7.12.1",
-        "tiny-warning": "^1.0.3"
-      }
     },
     "mini-css-extract-plugin": {
       "version": "2.4.5",
@@ -25603,6 +26333,11 @@
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "mmd-parser": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mmd-parser/-/mmd-parser-1.0.4.tgz",
+      "integrity": "sha512-Qi0VCU46t2IwfGv5KF0+D/t9cizcDug7qnNoy9Ggk7aucp0tssV8IwTMkBlDbm+VqAf3cdQHTCARKSsuS2MYFg=="
     },
     "ms": {
       "version": "2.1.2",
@@ -25985,6 +26720,15 @@
         "define-lazy-prop": "^2.0.0",
         "is-docker": "^2.1.1",
         "is-wsl": "^2.2.0"
+      }
+    },
+    "opentype.js": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/opentype.js/-/opentype.js-1.3.4.tgz",
+      "integrity": "sha512-d2JE9RP/6uagpQAVtJoF0pJJA/fgai89Cc50Yp0EJHk+eLp6QQ7gBoblsnubRULNY132I0J1QKMJ+JTbMqz4sw==",
+      "requires": {
+        "string.prototype.codepointat": "^0.2.1",
+        "tiny-inflate": "^1.0.3"
       }
     },
     "optionator": {
@@ -26949,6 +27693,11 @@
         }
       }
     },
+    "potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ=="
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -27148,12 +27897,11 @@
       }
     },
     "react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.0.0.tgz",
+      "integrity": "sha512-x+VL6wbT4JRVPm7EGxXhZ8w8LTROaxPXOqhlGyVSrv0sB1jkyFGgXxJ8LVoPRLvPR6/CIZGFmfzqUa2NYeMr2A==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "react-app-polyfill": {
@@ -27167,6 +27915,14 @@
         "raf": "^3.4.1",
         "regenerator-runtime": "^0.13.9",
         "whatwg-fetch": "^3.6.2"
+      }
+    },
+    "react-composer": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/react-composer/-/react-composer-5.0.2.tgz",
+      "integrity": "sha512-6E2UNjUF0e7KRY+/faU2Hv7D9zagXnYdTfSSCGdYfuds6mRnVpN19vrbHXShaQzJNVXL4VOUb8qq6DvClDIG1g==",
+      "requires": {
+        "prop-types": "^15.6.0"
       }
     },
     "react-dev-utils": {
@@ -27256,13 +28012,12 @@
       }
     },
     "react-dom": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.0.0.tgz",
+      "integrity": "sha512-XqX7uzmFo0pUceWFCt7Gff6IyIMzFUn7QMZrbrQfGxtaxXZIcGQzoNpRLE3fQLnS4XzLLPMZX2T9TRcSrasicw==",
       "requires": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
+        "scheduler": "^0.21.0"
       }
     },
     "react-error-overlay": {
@@ -27274,6 +28029,20 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "react-merge-refs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-1.1.0.tgz",
+      "integrity": "sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ=="
+    },
+    "react-reconciler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.27.0.tgz",
+      "integrity": "sha512-HmMDKciQjYmBRGuuhIaKA1ba/7a+UsM5FzOZsMO2JYHt9Jh8reCb7j1eDC95NOyUlKM9KRyvdx0flBuDvYSBoA==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.21.0"
+      }
     },
     "react-refresh": {
       "version": "0.11.0",
@@ -27301,6 +28070,15 @@
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "mini-create-react-context": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
+          "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
+          "requires": {
+            "@babel/runtime": "^7.12.1",
+            "tiny-warning": "^1.0.3"
+          }
         },
         "path-to-regexp": {
           "version": "1.8.0",
@@ -27384,6 +28162,14 @@
         "webpack-dev-server": "^4.6.0",
         "webpack-manifest-plugin": "^4.0.2",
         "workbox-webpack-plugin": "^6.4.1"
+      }
+    },
+    "react-use-measure": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.1.tgz",
+      "integrity": "sha512-nocZhN26cproIiIduswYpV5y5lQpSQS1y/4KuvUCjSKmw7ZWIS/+g3aFnX3WdBkyuGUtTLif3UTqnLLhbDoQig==",
+      "requires": {
+        "debounce": "^1.2.1"
       }
     },
     "read-pkg": {
@@ -27532,6 +28318,11 @@
       "version": "2.2.11",
       "resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.2.11.tgz",
       "integrity": "sha512-jbD/FT0+9MBU2XAZluI7w2OBs1RBi6p9M83nkoZayQXXU9e8Robt69FcZc7wU4eJD/YFTjn1JdCk3rbMJajz8Q=="
+    },
+    "regexp-to-ast": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
+      "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw=="
     },
     "regexp.prototype.flags": {
       "version": "1.3.1",
@@ -27927,12 +28718,11 @@
       }
     },
     "scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+      "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "schema-utils": {
@@ -28345,6 +29135,11 @@
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
       "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA=="
     },
+    "stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha1-scPcRtlEmLV4t/05hbgaznExzH0="
+    },
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
@@ -28420,6 +29215,11 @@
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.1"
       }
+    },
+    "string.prototype.codepointat": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
+      "integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg=="
     },
     "string.prototype.matchall": {
       "version": "4.0.6",
@@ -28546,6 +29346,12 @@
           }
         }
       }
+    },
+    "suspend-react": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.0.8.tgz",
+      "integrity": "sha512-ZC3r8Hu1y0dIThzsGw0RLZplnX9yXwfItcvaIzJc2VQVi8TGyGDlu92syMB5ulybfvGLHAI5Ghzlk23UBPF8xg==",
+      "requires": {}
     },
     "svg-parser": {
       "version": "2.0.4",
@@ -28768,6 +29574,34 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
     },
+    "three": {
+      "version": "0.139.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.139.1.tgz",
+      "integrity": "sha512-7mV5mk7k9CyNnRBXBo8VDWw0haONMh+czKfGFCaYhKq79br2z+4TxZe4JurM6/IGsLU3VaP8CydfDsifvZvg8w=="
+    },
+    "three-mesh-bvh": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.5.8.tgz",
+      "integrity": "sha512-aw1hGGKP91WC98vDh+M7yGczwnmmtbcCwDjsh7hls076S91GuSfWbCoym3GK64uR0BhySlV5mEitCKQu3o7srg==",
+      "requires": {}
+    },
+    "three-stdlib": {
+      "version": "2.8.12",
+      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.8.12.tgz",
+      "integrity": "sha512-Y0pl6mQKWM5rkdOYrx4PDFwMYEEx34z4bPwKALOqEtpjaZkWhiPpu7FKtipLiVdTd+Sw8Opty4q0QmJLZ2+Y4A==",
+      "requires": {
+        "@babel/runtime": "^7.16.7",
+        "@webgpu/glslang": "^0.0.15",
+        "chevrotain": "^10.1.2",
+        "draco3d": "^1.4.1",
+        "fflate": "^0.6.9",
+        "ktx-parse": "^0.2.1",
+        "mmd-parser": "^1.0.4",
+        "opentype.js": "^1.3.3",
+        "potpack": "^1.0.1",
+        "zstddec": "^0.0.2"
+      }
+    },
     "throat": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
@@ -28782,6 +29616,11 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
+    },
+    "tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="
     },
     "tiny-invariant": {
       "version": "1.2.0",
@@ -28853,6 +29692,28 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
       "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw=="
+    },
+    "troika-three-text": {
+      "version": "0.46.4",
+      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.46.4.tgz",
+      "integrity": "sha512-Qsv0HhUKTZgSmAJs5wvO7YlBoJSP9TGPLmrg+K9pbQq4lseQdcevbno/WI38bwJBZ/qS56hvfqEzY0zUEFzDIw==",
+      "requires": {
+        "bidi-js": "^1.0.2",
+        "troika-three-utils": "^0.46.0",
+        "troika-worker-utils": "^0.46.0",
+        "webgl-sdf-generator": "1.1.1"
+      }
+    },
+    "troika-three-utils": {
+      "version": "0.46.0",
+      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.46.0.tgz",
+      "integrity": "sha512-llHyrXAcwzr0bpg80GxsIp73N7FuImm4WCrKDJkAqcAsWmE5pfP9+Qzw+oMWK1P/AdHQ79eOrOl9NjyW4aOw0w==",
+      "requires": {}
+    },
+    "troika-worker-utils": {
+      "version": "0.46.0",
+      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.46.0.tgz",
+      "integrity": "sha512-bzOx5f2ZBxkFhXtIvDJlLn2AI3bzCkGVbCndl/2dL5QZrwHEKl45OEIilCxYQQWJG1rEbOD9O80tMjoYjw19OA=="
     },
     "true-case-path": {
       "version": "1.0.3",
@@ -29091,6 +29952,11 @@
       "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
       "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw="
     },
+    "utility-types": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.10.0.tgz",
+      "integrity": "sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg=="
+    },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -29192,6 +30058,16 @@
       "requires": {
         "minimalistic-assert": "^1.0.0"
       }
+    },
+    "webgl-constants": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
+    },
+    "webgl-sdf-generator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
+      "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA=="
     },
     "webidl-conversions": {
       "version": "6.1.0",
@@ -29878,6 +30754,17 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+    },
+    "zstddec": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.0.2.tgz",
+      "integrity": "sha512-DCo0oxvcvOTGP/f5FA6tz2Z6wF+FIcEApSTu0zV5sQgn9hoT5lZ9YRAKUraxt9oP7l4e8TnNdi8IZTCX6WCkwA=="
+    },
+    "zustand": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.7.1.tgz",
+      "integrity": "sha512-wHBCZlKj+bg03/hP+Tzv24YhnqqP8MCeN9ECPDXoF01062SIbnfl3j9O0znkDw1lNTY0a8WN3F///a0UhhaEqg==",
+      "requires": {}
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,13 +3,16 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@react-three/drei": "^9.0.1",
+    "@react-three/fiber": "^8.0.4",
     "axios": "^0.24.0",
     "node-gyp": "^8.4.1",
     "node-sass": "^7.0.1",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-router-dom": "^5.3.0",
-    "react-scripts": "^5.0.0"
+    "react-scripts": "^5.0.0",
+    "three": "^0.139.1"
   },
   "scripts": {
     "dev": "react-scripts start",

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
-import Header from "components/views/Header";
 import AppRouter from "components/routing/routers/AppRouter";
+import Header from "components/views/Header";
 
 /**
  * Happy coding!
@@ -8,9 +8,9 @@ import AppRouter from "components/routing/routers/AppRouter";
  */
 const App = () => {
   return (
-    <div>
-      <Header height="100"/>
-      <AppRouter/>
+    <div style={{ height: "100vh" }}>
+      <Header height="100" />
+      <AppRouter />
     </div>
   );
 };

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,9 +1,10 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import App from './App';
+import React from "react";
+import ReactDOM from "react-dom";
+import App from "./App";
 
-it('renders without crashing', () => {
-  const div = document.createElement('div');
-  ReactDOM.render(<App />, div);
+it("renders without crashing", () => {
+  const div = document.createElement("div");
+  const root = ReactDOM.createRoot(document.getElementById("root"));
+  root.render(<App />, div);
   ReactDOM.unmountComponentAtNode(div);
 });

--- a/src/components/routing/routers/AppRouter.js
+++ b/src/components/routing/routers/AppRouter.js
@@ -1,8 +1,9 @@
-import {BrowserRouter, Redirect, Route, Switch} from "react-router-dom";
-import {GameGuard} from "components/routing/routeProtectors/GameGuard";
+import { GameGuard } from "components/routing/routeProtectors/GameGuard";
+import { LoginGuard } from "components/routing/routeProtectors/LoginGuard";
 import GameRouter from "components/routing/routers/GameRouter";
-import {LoginGuard} from "components/routing/routeProtectors/LoginGuard";
 import Login from "components/views/Login";
+import Test from "components/views/Test";
+import { BrowserRouter, Redirect, Route, Switch } from "react-router-dom";
 
 /**
  * Main router of your application.
@@ -19,16 +20,19 @@ const AppRouter = () => {
       <Switch>
         <Route path="/game">
           <GameGuard>
-            <GameRouter base="/game"/>
+            <GameRouter base="/game" />
           </GameGuard>
         </Route>
         <Route exact path="/login">
           <LoginGuard>
-            <Login/>
+            <Login />
           </LoginGuard>
         </Route>
         <Route exact path="/">
-          <Redirect to="/game"/>
+          <Redirect to="/game" />
+        </Route>
+        <Route exact path="/test">
+          <Test />
         </Route>
       </Switch>
     </BrowserRouter>
@@ -36,6 +40,6 @@ const AppRouter = () => {
 };
 
 /*
-* Don't forget to export your component!
+ * Don't forget to export your component!
  */
 export default AppRouter;

--- a/src/components/ui/Box.js
+++ b/src/components/ui/Box.js
@@ -1,0 +1,26 @@
+import { useFrame } from "@react-three/fiber";
+import { useRef, useState } from "react";
+import "styles/views/Game.scss";
+
+const Box = (props) => {
+  const mesh = useRef();
+  const [hover, setHover] = useState(false);
+  const [active, setActive] = useState(false);
+
+  useFrame((state, delta) => (mesh.current.rotation.x += 0.01));
+  return (
+    <mesh
+      {...props}
+      ref={mesh}
+      scale={active ? 1.5 : 1}
+      onClick={(event) => setActive(!active)}
+      onPointerOver={(event) => setHover(true)}
+      onPointerOut={(event) => setHover(false)}
+    >
+      <boxGeometry args={[1, 1, 1]} />
+      <meshStandardMaterial color={hover ? "hotpink" : "orange"} />
+    </mesh>
+  );
+};
+
+export default Box;

--- a/src/components/ui/Scene.js
+++ b/src/components/ui/Scene.js
@@ -1,0 +1,349 @@
+import { PerspectiveCamera, useGLTF } from "@react-three/drei";
+import { useRef } from "react";
+import "styles/views/Game.scss";
+
+export const Scene = (props) => {
+  const group = useRef();
+  const { nodes, materials } = useGLTF("gltf/blender_dog_everything.gltf");
+
+  return (
+    <group ref={group} {...props} dispose={null}>
+      <group position={[0, 8.16, 0]}>
+        <pointLight intensity={1} decay={2} rotation={[-Math.PI / 2, 0, 0]} />
+      </group>
+      <group position={[1.83, 1.15, 1.72]} rotation={[1.24, 0.33, -0.76]}>
+        <PerspectiveCamera
+          makeDefault={true}
+          far={100}
+          near={0.1}
+          fov={22.9}
+          rotation={[-Math.PI / 2, 0, 0]}
+        />
+      </group>
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Cube.geometry}
+        material={materials.Material}
+        scale={[0.6, 0.01, 0.6]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle.geometry}
+        material={nodes.Circle.material}
+        position={[-0.14, 0.01, 0.52]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle001.geometry}
+        material={nodes.Circle001.material}
+        position={[0, 0.01, 0.52]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle002.geometry}
+        material={nodes.Circle002.material}
+        position={[-0.21, 0.01, 0.52]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle003.geometry}
+        material={nodes.Circle003.material}
+        position={[-0.07, 0.01, 0.52]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle004.geometry}
+        material={nodes.Circle004.material}
+        position={[-0.33, 0.01, 0.52]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle005.geometry}
+        material={nodes.Circle005.material}
+        position={[-0.35, 0.01, 0.42]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle006.geometry}
+        material={nodes.Circle006.material}
+        position={[-0.35, 0.01, 0.35]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle007.geometry}
+        material={nodes.Circle007.material}
+        position={[-0.31, 0.01, 0.3]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle008.geometry}
+        material={nodes.Circle008.material}
+        position={[-0.26, 0.01, 0.26]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle009.geometry}
+        material={nodes.Circle009.material}
+        position={[-0.53, 0.01, -0.14]}
+        rotation={[0, -1.57, 0]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle010.geometry}
+        material={nodes.Circle010.material}
+        position={[-0.53, 0.01, 0]}
+        rotation={[0, -1.57, 0]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle011.geometry}
+        material={nodes.Circle011.material}
+        position={[-0.53, 0.01, -0.21]}
+        rotation={[0, -1.57, 0]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle012.geometry}
+        material={nodes.Circle012.material}
+        position={[-0.53, 0.01, -0.07]}
+        rotation={[0, -1.57, 0]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle013.geometry}
+        material={nodes.Circle013.material}
+        position={[-0.53, 0.01, -0.34]}
+        rotation={[0, -1.57, 0]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle014.geometry}
+        material={nodes.Circle014.material}
+        position={[-0.42, 0.01, -0.35]}
+        rotation={[0, -1.57, 0]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle015.geometry}
+        material={nodes.Circle015.material}
+        position={[-0.35, 0.01, -0.35]}
+        rotation={[0, -1.57, 0]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle016.geometry}
+        material={nodes.Circle016.material}
+        position={[-0.31, 0.01, -0.31]}
+        rotation={[0, -1.57, 0]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle017.geometry}
+        material={nodes.Circle017.material}
+        position={[-0.26, 0.01, -0.26]}
+        rotation={[0, -1.57, 0]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle018.geometry}
+        material={nodes.Circle018.material}
+        position={[0.14, 0.01, -0.53]}
+        rotation={[-Math.PI, 0, -Math.PI]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle019.geometry}
+        material={nodes.Circle019.material}
+        position={[0, 0.01, -0.53]}
+        rotation={[-Math.PI, 0, -Math.PI]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle020.geometry}
+        material={nodes.Circle020.material}
+        position={[0.21, 0.01, -0.53]}
+        rotation={[-Math.PI, 0, -Math.PI]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle021.geometry}
+        material={nodes.Circle021.material}
+        position={[0.07, 0.01, -0.53]}
+        rotation={[-Math.PI, 0, -Math.PI]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle022.geometry}
+        material={nodes.Circle022.material}
+        position={[0.33, 0.01, -0.53]}
+        rotation={[-Math.PI, 0, -Math.PI]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle023.geometry}
+        material={nodes.Circle023.material}
+        position={[0.35, 0.01, -0.42]}
+        rotation={[-Math.PI, 0, -Math.PI]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle024.geometry}
+        material={nodes.Circle024.material}
+        position={[0.35, 0.01, -0.35]}
+        rotation={[-Math.PI, 0, -Math.PI]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle025.geometry}
+        material={nodes.Circle025.material}
+        position={[0.3, 0.01, -0.3]}
+        rotation={[-Math.PI, 0, -Math.PI]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle026.geometry}
+        material={nodes.Circle026.material}
+        position={[0.26, 0.01, -0.25]}
+        rotation={[-Math.PI, 0, -Math.PI]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle027.geometry}
+        material={nodes.Circle027.material}
+        position={[0.52, 0.01, 0.13]}
+        rotation={[0, 1.55, 0]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle028.geometry}
+        material={nodes.Circle028.material}
+        position={[0.52, 0.01, 0]}
+        rotation={[0, 1.55, 0]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle029.geometry}
+        material={nodes.Circle029.material}
+        position={[0.52, 0.01, 0.2]}
+        rotation={[0, 1.55, 0]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle030.geometry}
+        material={nodes.Circle030.material}
+        position={[0.52, 0.01, 0.07]}
+        rotation={[0, 1.55, 0]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle031.geometry}
+        material={nodes.Circle031.material}
+        position={[0.52, 0.01, 0.33]}
+        rotation={[0, 1.55, 0]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle032.geometry}
+        material={nodes.Circle032.material}
+        position={[0.42, 0.01, 0.34]}
+        rotation={[0, 1.55, 0]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle033.geometry}
+        material={nodes.Circle033.material}
+        position={[0.35, 0.01, 0.35]}
+        rotation={[0, 1.55, 0]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle034.geometry}
+        material={nodes.Circle034.material}
+        position={[0.3, 0.01, 0.3]}
+        rotation={[0, 1.55, 0]}
+        scale={[0.03, 1, 0.03]}
+      />
+      <mesh
+        castShadow
+        receiveShadow
+        geometry={nodes.Circle035.geometry}
+        material={nodes.Circle035.material}
+        position={[0.25, 0.01, 0.25]}
+        rotation={[0, 1.55, 0]}
+        scale={[0.03, 1, 0.03]}
+      />
+    </group>
+  );
+};
+
+useGLTF.preload("gltf/blender_dog_everything.gltf");

--- a/src/components/views/Header.js
+++ b/src/components/views/Header.js
@@ -1,6 +1,5 @@
-import React from "react";
-import {ReactLogo} from "components/ui/ReactLogo";
 import PropTypes from "prop-types";
+import React from "react";
 import "styles/views/Header.scss";
 
 /**
@@ -11,15 +10,14 @@ import "styles/views/Header.scss";
  * https://reactjs.org/docs/components-and-props.html
  * @FunctionalComponent
  */
-const Header = props => (
-  <div className="header container" style={{height: props.height}}>
+const Header = (props) => (
+  <div className="header container" style={{ height: props.height }}>
     <h1 className="header title">SoPra FS22 rocks with React!</h1>
-    <ReactLogo width="60px" height="60px"/>
   </div>
 );
 
 Header.propTypes = {
-  height: PropTypes.string
+  height: PropTypes.string,
 };
 
 /**

--- a/src/components/views/Test.js
+++ b/src/components/views/Test.js
@@ -1,0 +1,25 @@
+import { Canvas } from "@react-three/fiber";
+import { Scene } from "components/ui/Scene";
+import { Suspense } from "react";
+
+// drop .gltf file at https://gltf.pmnd.rs/, to be able to access every single component
+const Test = (props) => {
+  return (
+    // Box example
+    // <Canvas camera={{ position: [0, 0, 7], near: 1, far: 100, fov: 45 }}>
+    //   <ambientLight />
+    //   <pointLight position={[10, 10, 10]} />
+    //   <Box position={[-1.2, 0, 0]} />
+    //   <Box position={[1.2, 0, 0]} />
+    // </Canvas>
+
+    // Loading our brändy dog board
+    <Canvas dpr={Math.max(window.devicePixelRatio, 2)}>
+      <Suspense fallback={null}>
+        <Scene />
+      </Suspense>
+    </Canvas>
+  );
+};
+
+export default Test;

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
-import React from "react";
-import ReactDOM from "react-dom";
-import "styles/index.scss";
 import App from "App";
+import React from "react";
+import reactDom from "react-dom/client";
+import "styles/index.scss";
 
 /**
  * This is the entry point of your React application where the root element is in the public/index.html.
@@ -9,4 +9,5 @@ import App from "App";
  * Applications built with just React usually have a single root DOM node.
  * More: https://reactjs.org/docs/rendering-elements.html
  */
-ReactDOM.render(<App />, document.getElementById("root"));
+const root = reactDom.createRoot(document.getElementById("root"));
+root.render(<App />);


### PR DESCRIPTION
Create /test url to test 3D stuff.
Drag and drop our model to https://gltf.pmnd.rs/, which converts it into different models.
Remove React logo, that constantly changes width and height of the viewport.
Create two examples to test ThreeJS:
 1. An example with two Boxes that you can interact with.
 2. An import of our Brändy Dog model.

Update React version in order to use use threejs.

dependencies:
 - update react 17.0.2 -> 18.0.0
 - install three and @react-three/fiber
 - install @react-three/drei, in order to load GLTF models