### PR TITLE
fix: Remove random connects to websockets

### DIFF
--- a/src/components/views/Game.js
+++ b/src/components/views/Game.js
@@ -156,7 +156,7 @@ const Game = () => {
         className="login button"
         disabled={!enterCode}
         onClick={() => {
-          connectToWebsocket(enterCode);
+          // connectToWebsocket(enterCode);
           enterLobby(enterCode);
         }}
       >
@@ -177,7 +177,7 @@ const Game = () => {
           <Button
             className="login button"
             onClick={() => {
-              connectToWebsocket(createCode);
+              // connectToWebsocket(createCode);
               enterLobby(createCode);
             }}
           >
@@ -195,7 +195,7 @@ const Game = () => {
           className="login button"
           disabled={!enterCode}
           onClick={() => {
-            connectToWebsocket(enterCode);
+            // connectToWebsocket(enterCode);
             enterLobby(enterCode);
           }}
         >


### PR DESCRIPTION
After clicking a button, we tried to establish a connection for websockets
before initializing the state.

The websockets connect() function should only be called in the BasicBoard component
in the useEffect